### PR TITLE
feat: Add multi-LLM support (OpenAI, Claude, Gemini) and robust script generation

### DIFF
--- a/Editor/CAIGSettings.cs
+++ b/Editor/CAIGSettings.cs
@@ -29,6 +29,9 @@ namespace OojuInteractionPlugin
         // API settings
         [SerializeField] private string apiKey = "";
         [SerializeField] private string baseUrl = "https://api.ooju.com";
+        [SerializeField] private string claudeApiKey = "";
+        [SerializeField] private string geminiApiKey = "";
+        [SerializeField] private string selectedLLMType = "OpenAI";
 
         // Animation settings
         [SerializeField] private float defaultHoverAmplitude = 0.5f;
@@ -123,10 +126,17 @@ namespace OojuInteractionPlugin
             }
         }
 
+        public string ClaudeApiKey { get => claudeApiKey; set { claudeApiKey = value; SaveSettings(); } }
+        public string GeminiApiKey { get => geminiApiKey; set { geminiApiKey = value; SaveSettings(); } }
+        public string SelectedLLMType { get => selectedLLMType; set { selectedLLMType = value; SaveSettings(); } }
+
         // Save settings to PlayerPrefs
         public void SaveSettings()
         {
             PlayerPrefs.SetString("CAIG_ApiKey", apiKey);
+            PlayerPrefs.SetString("CAIG_ClaudeApiKey", claudeApiKey);
+            PlayerPrefs.SetString("CAIG_GeminiApiKey", geminiApiKey);
+            PlayerPrefs.SetString("CAIG_SelectedLLMType", selectedLLMType);
             PlayerPrefs.SetString("CAIG_BaseUrl", baseUrl);
             PlayerPrefs.SetFloat("CAIG_HoverAmplitude", defaultHoverAmplitude);
             PlayerPrefs.SetFloat("CAIG_HoverFrequency", defaultHoverFrequency);
@@ -141,6 +151,9 @@ namespace OojuInteractionPlugin
         public void LoadSettings()
         {
             apiKey = PlayerPrefs.GetString("CAIG_ApiKey", "");
+            claudeApiKey = PlayerPrefs.GetString("CAIG_ClaudeApiKey", "");
+            geminiApiKey = PlayerPrefs.GetString("CAIG_GeminiApiKey", "");
+            selectedLLMType = PlayerPrefs.GetString("CAIG_SelectedLLMType", "OpenAI");
             baseUrl = PlayerPrefs.GetString("CAIG_BaseUrl", "https://api.ooju.com");
             defaultHoverAmplitude = PlayerPrefs.GetFloat("CAIG_HoverAmplitude", 0.5f);
             defaultHoverFrequency = PlayerPrefs.GetFloat("CAIG_HoverFrequency", 1f);

--- a/Editor/IOISettings.cs
+++ b/Editor/IOISettings.cs
@@ -10,6 +10,9 @@ namespace OojuInteractionPlugin
         float DefaultWobbleSpeed { get; set; }
         float DefaultScaleAmount { get; set; }
         float DefaultScaleSpeed { get; set; }
+        string ClaudeApiKey { get; set; } // Claude API key
+        string GeminiApiKey { get; set; } // Gemini API key
+        string SelectedLLMType { get; set; } // Selected LLM type: "OpenAI", "Claude", or "Gemini"
         void SaveSettings();
         void LoadSettings();
     }

--- a/Editor/LLMServices.cs
+++ b/Editor/LLMServices.cs
@@ -1,0 +1,197 @@
+using System.Threading.Tasks;
+using UnityEngine.Networking;
+using System.Text;
+using Newtonsoft.Json;
+using System;
+
+namespace OojuInteractionPlugin
+{
+    // Interface for LLM service abstraction
+    public interface ILLMService
+    {
+        Task<string> RequestInteraction(string prompt);
+    }
+
+    // OpenAI implementation
+    public class OpenAIService : ILLMService
+    {
+        private string apiKey;
+        private const string OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+        private const string MODEL = "gpt-4o";
+        public OpenAIService(string apiKey) { this.apiKey = apiKey; }
+        public async Task<string> RequestInteraction(string prompt)
+        {
+            if (string.IsNullOrEmpty(apiKey))
+                throw new Exception("OpenAI API Key is not set");
+            var requestData = new
+            {
+                model = MODEL,
+                messages = new[] { new { role = "user", content = prompt } },
+                max_tokens = 800,
+                temperature = 0.6
+            };
+            string jsonData = JsonConvert.SerializeObject(requestData);
+            using (UnityWebRequest request = new UnityWebRequest(OPENAI_API_URL, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(jsonData);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+                request.SetRequestHeader("Authorization", $"Bearer {apiKey}");
+                await request.SendWebRequestAsync();
+                if (request.result == UnityWebRequest.Result.Success)
+                {
+                    var response = JsonConvert.DeserializeObject<OpenAIResponse>(request.downloadHandler.text);
+                    return response?.choices?[0]?.message?.content ?? "No response generated";
+                }
+                else
+                {
+                    string errorMessage = $"OpenAI API Error: {request.error}";
+                    return errorMessage;
+                }
+            }
+        }
+        // OpenAI response classes
+        [Serializable]
+        public class OpenAIResponse { public Choice[] choices; }
+        [Serializable]
+        public class Choice { public Message message; }
+        [Serializable]
+        public class Message { public string content; }
+    }
+
+    // Claude (Anthropic) implementation
+    public class ClaudeService : ILLMService
+    {
+        private string apiKey;
+        private const string CLAUDE_API_URL = "https://api.anthropic.com/v1/messages";
+        private const string MODEL = "claude-opus-4-20250514";
+        public ClaudeService(string apiKey) { this.apiKey = apiKey; }
+        public async Task<string> RequestInteraction(string prompt)
+        {
+            if (string.IsNullOrEmpty(apiKey))
+                throw new Exception("Claude API Key is not set");
+            var requestData = new
+            {
+                model = MODEL,
+                max_tokens = 1024,
+                messages = new[] {
+                    new { role = "user", content = prompt }
+                }
+            };
+            string jsonData = JsonConvert.SerializeObject(requestData);
+            using (UnityWebRequest request = new UnityWebRequest(CLAUDE_API_URL, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(jsonData);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+                request.SetRequestHeader("x-api-key", apiKey);
+                request.SetRequestHeader("anthropic-version", "2023-06-01");
+                await request.SendWebRequestAsync();
+                if (request.result == UnityWebRequest.Result.Success)
+                {
+                    var response = JsonConvert.DeserializeObject<ClaudeResponse>(request.downloadHandler.text);
+                    if (response?.content != null && response.content.Length > 0)
+                        return response.content[0].text;
+                    return "No response generated";
+                }
+                else
+                {
+                    string errorMessage = $"Claude API Error: {request.error}";
+                    return errorMessage;
+                }
+            }
+        }
+        [Serializable]
+        public class ClaudeResponse
+        {
+            public ClaudeContent[] content;
+        }
+        [Serializable]
+        public class ClaudeContent
+        {
+            public string type;
+            public string text;
+        }
+    }
+
+    // Gemini (Google) implementation
+    public class GeminiService : ILLMService
+    {
+        private string apiKey;
+        private const string GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
+        public GeminiService(string apiKey) { this.apiKey = apiKey; }
+        public async Task<string> RequestInteraction(string prompt)
+        {
+            if (string.IsNullOrEmpty(apiKey))
+                throw new Exception("Gemini API Key is not set");
+            var requestData = new
+            {
+                contents = new[] {
+                    new {
+                        parts = new[] {
+                            new { text = prompt }
+                        }
+                    }
+                }
+            };
+            string jsonData = JsonConvert.SerializeObject(requestData);
+            string url = $"{GEMINI_API_URL}?key={apiKey}";
+            using (UnityWebRequest request = new UnityWebRequest(url, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(jsonData);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+                await request.SendWebRequestAsync();
+                if (request.result == UnityWebRequest.Result.Success)
+                {
+                    var response = JsonConvert.DeserializeObject<GeminiResponse>(request.downloadHandler.text);
+                    // Gemini returns candidates[0].content.parts[0].text
+                    if (response?.candidates != null && response.candidates.Length > 0 &&
+                        response.candidates[0].content?.parts != null && response.candidates[0].content.parts.Length > 0)
+                        return response.candidates[0].content.parts[0].text;
+                    return "No response generated";
+                }
+                else
+                {
+                    string errorMessage = $"Gemini API Error: {request.error}";
+                    return errorMessage;
+                }
+            }
+        }
+        [Serializable]
+        public class GeminiResponse
+        {
+            public GeminiCandidate[] candidates;
+        }
+        [Serializable]
+        public class GeminiCandidate
+        {
+            public GeminiContent content;
+        }
+        [Serializable]
+        public class GeminiContent
+        {
+            public GeminiPart[] parts;
+        }
+        [Serializable]
+        public class GeminiPart
+        {
+            public string text;
+        }
+    }
+
+    // Extension method for UnityWebRequest to support async/await
+    public static class UnityWebRequestExtensions
+    {
+        public static Task<UnityWebRequest> SendWebRequestAsync(this UnityWebRequest request)
+        {
+            var tcs = new TaskCompletionSource<UnityWebRequest>();
+            var operation = request.SendWebRequest();
+            operation.completed += _ => tcs.SetResult(request);
+            return tcs.Task;
+        }
+    }
+} 

--- a/Editor/LLMServices.cs.meta
+++ b/Editor/LLMServices.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4bd88a1169e5e1a43b7ab7556d067fdf


### PR DESCRIPTION
- Refactor LLM service architecture to support OpenAI, Claude, and Gemini via a unified interface
- Add settings UI for selecting LLM model and managing API keys for each provider
- Implement real API integration for Claude (Anthropic) and Gemini (Google) based on official docs
- Ensure generated scripts always inherit from MonoBehaviour (prompt enforcement + code post-processing)
- Fix error handling to check only the selected model's API key
- Improve robustness of script assignment and error messages
- Fix GUI layout and component assignment issues for generated scripts